### PR TITLE
Change provider constructor to return interface

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: func() terraform.ResourceProvider {
-			return provider.New()
+			return provider.Provider()
 		},
 	})
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/kyma-incubator/terraform-provider-gardener/client"
 	"github.com/kyma-incubator/terraform-provider-gardener/shoot"
 )
@@ -10,7 +11,7 @@ import (
 // Global MutexKV
 var mutexKV = mutexkv.NewMutexKV()
 
-func New() *schema.Provider {
+func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"profile": {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Change the provider constructor to return interface instead of the schema, so we can use the provider programatically.
