### PR TITLE
Add Timeouts for operations, do not fail on errors

### DIFF
--- a/shoot/resource_shoot.go
+++ b/shoot/resource_shoot.go
@@ -2,6 +2,7 @@ package shoot
 
 import (
 	"fmt"
+	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardener_types "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
@@ -16,6 +17,12 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	defaultCreateTimeout = time.Minute * 30
+	defaultUpdateTimeout = time.Minute * 30
+	defaultDeleteTimeout = time.Minute * 20
+)
+
 func ResourceShoot() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceServerCreate,
@@ -23,6 +30,11 @@ func ResourceShoot() *schema.Resource {
 		Exists: resourceServerExists,
 		Update: resourceServerUpdate,
 		Delete: resourceServerDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(defaultCreateTimeout),
+			Update: schema.DefaultTimeout(defaultUpdateTimeout),
+			Delete: schema.DefaultTimeout(defaultDeleteTimeout),
+		},
 		Schema: map[string]*schema.Schema{
 			"metadata": namespacedMetadataSchema("shoot", false),
 			"spec":     shootSpecSchema(),
@@ -164,7 +176,7 @@ func waitForShootFunc(shootsClient gardener_apis.ShootInterface, name string) re
 					return resource.RetryableError(fmt.Errorf("Waiting for shoot condition to finish: %s", condition.Type))
 				}
 				if condition.Status == gardencorev1alpha1.ConditionFalse {
-					return resource.NonRetryableError(fmt.Errorf("Shoot condition failed: %s", condition.Message))
+					return resource.RetryableError(fmt.Errorf("Shoot condition failed: %s", condition.Message))
 				}
 			}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add default timeouts for operations
- Do not fail when conditions are in a false state as Gardener still can reconcile to successful state

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
