### PR TITLE
add oidc_config support in schema.go

### DIFF
--- a/shoot/schema_shoot.go
+++ b/shoot/schema_shoot.go
@@ -121,6 +121,62 @@ func kubernetesResource() *schema.Resource {
 							Description: "enable basic authentication flag.",
 							Optional:    true,
 						},
+						"oidc_config": {
+							Type:             schema.TypeList,
+							Description:      "interface for adding oidc_config in kube api server section",
+							MaxItems:         1,
+							Optional:         true,
+							DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ca_bundle": {
+										Type:        schema.TypeString,
+										Description: "ca_bundle for oidc config in kube api server section",
+										Optional:    true,
+									},
+									"client_id": {
+										Type:        schema.TypeString,
+										Description: "client_id for oidc config in kube api server section",
+										Optional:    true,
+									},
+									"groups_claim": {
+										Type:        schema.TypeString,
+										Description: "groups_claim for oidc config in kube api server section",
+										Optional:    true,
+									},
+									"groups_prefix": {
+										Type:        schema.TypeString,
+										Description: "groups_prefix for oidc config in kube api server section",
+										Optional:    true,
+									},
+									"issuer_url": {
+										Type:        schema.TypeString,
+										Description: "issuer_url for oidc config in kube api server section",
+										Optional:    true,
+									},
+									"required_claims": {
+										Type:        schema.TypeString,
+										Description: "required_claims for oidc config in kube api server section",
+										Optional:    true,
+									},
+									"signing_algs": {
+										Type:        schema.TypeString,
+										Description: "signing_algs for oidc config in kube api server section",
+										Optional:    true,
+									},
+									"username_claim": {
+										Type:        schema.TypeString,
+										Description: "username_claim for oidc config in kube api server section",
+										Optional:    true,
+									},
+									"username_prefix": {
+										Type:        schema.TypeString,
+										Description: "username_prefix for oidc config in kube api server section",
+										Optional:    true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
during my utilization of terraform-provider-gardener i found in the spec->kubernetes->kube_api_server, the oidc_config part is implemented in https://github.com/kyma-incubator/terraform-provider-gardener/blob/6221849d07f099d83c1f76281a5ea07df7f55ff6/expand/expand_spec.go#L322 , but not exposed in schema_shoot.go https://github.com/kyma-incubator/terraform-provider-gardener/blob/301c93bd06e57bb52483daad1b26411b7fc95fcb/shoot/schema_shoot.go#L104

so i prepared this PR to add implementation for oidc_config

Tested locally with sth like this
in examples/aws/main.tf , and then run `tf init`, `tf plan`
```
    kubernetes {
      version = "1.15.4"
      kube_api_server {
        enable_basic_authentication = false
        oidc_config {
          client_id = "aaa"
          groups_claim = "aaa"
          issuer_url = "aaa"
          username_claim = "aaa"
      }
     }
    }
```