### PR TITLE
add auditPolicy in schema_shoot.go

### DIFF
--- a/shoot/expand_spec_test.go
+++ b/shoot/expand_spec_test.go
@@ -3,8 +3,9 @@ package shoot
 
 import (
 	"encoding/json"
-	gcpAlpha1 "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/v1alpha1"
 	"testing"
+
+	gcpAlpha1 "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/v1alpha1"
 
 	awsAlpha1 "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
 	azAlpha1 "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
@@ -55,6 +56,23 @@ func TestExpandShoot(t *testing.T) {
 				"kubernetes": []interface{}{
 					map[string]interface{}{
 						"version": "1.15.4",
+						"kube_api_server": []interface{}{
+							map[string]interface{}{
+								"audit_config": []interface{}{
+									map[string]interface{}{
+										"audit_policy": []interface{}{
+											map[string]interface{}{
+												"config_map_ref": []interface{}{
+													map[string]interface{}{
+														"name": "audit-policy",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 				"maintenance": []interface{}{
@@ -245,6 +263,15 @@ func TestExpandShoot(t *testing.T) {
 		Kubernetes: corev1beta1.Kubernetes{
 			Version:                   "1.15.4",
 			AllowPrivilegedContainers: &allowPrivilegedContainers,
+			KubeAPIServer: &corev1beta1.KubeAPIServerConfig{
+				AuditConfig: &corev1beta1.AuditConfig{
+					AuditPolicy: &corev1beta1.AuditPolicy{
+						ConfigMapRef: &corev1.ObjectReference{
+							Name: "audit-policy",
+						},
+					},
+				},
+			},
 		},
 		DNS: &corev1beta1.DNS{
 			Domain: &domain,

--- a/shoot/schema_shoot.go
+++ b/shoot/schema_shoot.go
@@ -177,6 +177,41 @@ func kubernetesResource() *schema.Resource {
 								},
 							},
 						},
+						"audit_config": {
+							Type:        schema.TypeList,
+							Description: "Audit Config contains customized audit config info.",
+							Optional:    true,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"audit_policy": {
+										Type:        schema.TypeList,
+										Description: "Audit Policy contains customized audit policy info.",
+										Optional:    true,
+										MaxItems:    1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"config_map_ref": {
+													Type:        schema.TypeList,
+													Description: "Config Map Ref contains customized config map ref info.",
+													Optional:    true,
+													MaxItems:    1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"name": {
+																Type:        schema.TypeString,
+																Description: "name of the config map ref",
+																Optional:    true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
this is to add auditPolicy for shoot, refer to https://github.com/gardener/gardener/blob/232b765f32eb7503f71c1fe6c35c1cd9f6fef531/example/90-shoot.yaml#L128

currently auditPolicy logic already exist in expand_spec.go so adding missing part in schema_shoot.go

tested locally
![image](https://user-images.githubusercontent.com/42594392/77057331-c119c780-6a0e-11ea-9766-b7371fa53953.png)
