### PR TITLE
fix missing kube api basic auth property

### DIFF
--- a/expand/expand_spec.go
+++ b/expand/expand_spec.go
@@ -325,6 +325,10 @@ func expandKubernetesAPIServer(server []interface{}) *corev1beta1.KubeAPIServerC
 	if v, ok := in["runtime_config"].(map[string]interface{}); ok {
 		obj.RuntimeConfig = expandBoolMap(v)
 	}
+
+	if v, ok := in["enable_basic_authentication"].(bool); ok {
+		obj.EnableBasicAuthentication = &v
+	}
 	if v, ok := in["oidc_config"].([]interface{}); ok && len(v) > 0 {
 		v := v[0].(map[string]interface{})
 		obj.OIDCConfig = &corev1beta1.OIDCConfig{}

--- a/flatten/flatten_spec.go
+++ b/flatten/flatten_spec.go
@@ -151,12 +151,12 @@ func flattenKubernetes(in corev1beta1.Kubernetes) []interface{} {
 	att := make(map[string]interface{})
 
 	if in.AllowPrivilegedContainers != nil {
-		att["allow_privileged_containers"] = in.AllowPrivilegedContainers
+		att["allow_privileged_containers"] = *in.AllowPrivilegedContainers
 	}
 	if in.KubeAPIServer != nil {
 		server := make(map[string]interface{})
-		if in.KubeAPIServer.FeatureGates != nil {
-			server["enable_basic_authentication"] = in.KubeAPIServer.EnableBasicAuthentication
+		if in.KubeAPIServer.EnableBasicAuthentication != nil {
+			server["enable_basic_authentication"] = *in.KubeAPIServer.EnableBasicAuthentication
 		}
 		att["kube_api_server"] = []interface{}{server}
 	}

--- a/shoot/expand_spec_test.go
+++ b/shoot/expand_spec_test.go
@@ -35,7 +35,8 @@ func TestExpandShoot(t *testing.T) {
 	hibernationStart := "00 17 * * 1"
 	hibernationEnd := "00 00 * * 1"
 	hibernationEnabled := true
-	allowPrivilegedContainers := false
+	allowPrivilegedContainers := true
+	enableBasicAuthentication := true
 
 	shoot := map[string]interface{}{
 		"spec": []interface{}{
@@ -54,7 +55,13 @@ func TestExpandShoot(t *testing.T) {
 				},
 				"kubernetes": []interface{}{
 					map[string]interface{}{
-						"version": "1.15.4",
+						"version":                     "1.15.4",
+						"allow_privileged_containers": true,
+						"kube_api_server": []interface{}{
+							map[string]interface{}{
+								"enable_basic_authentication": true,
+							},
+						},
 					},
 				},
 				"maintenance": []interface{}{
@@ -245,6 +252,9 @@ func TestExpandShoot(t *testing.T) {
 		Kubernetes: corev1beta1.Kubernetes{
 			Version:                   "1.15.4",
 			AllowPrivilegedContainers: &allowPrivilegedContainers,
+			KubeAPIServer: &corev1beta1.KubeAPIServerConfig{
+				EnableBasicAuthentication: &enableBasicAuthentication,
+			},
 		},
 		DNS: &corev1beta1.DNS{
 			Domain: &domain,

--- a/shoot/expand_spec_test.go
+++ b/shoot/expand_spec_test.go
@@ -56,7 +56,7 @@ func TestExpandShoot(t *testing.T) {
 				},
 				"kubernetes": []interface{}{
 					map[string]interface{}{
-						"version": "1.15.4",
+						"version":                     "1.15.4",
 						"allow_privileged_containers": true,
 						"kube_api_server": []interface{}{
 							map[string]interface{}{
@@ -216,7 +216,7 @@ func TestExpandShoot(t *testing.T) {
 		},
 		Provider: corev1beta1.Provider{
 			Workers: []corev1beta1.Worker{
-				corev1beta1.Worker{
+				{
 					MaxSurge: &intstr.IntOrString{
 						IntVal: 1,
 					},
@@ -246,7 +246,7 @@ func TestExpandShoot(t *testing.T) {
 					CABundle: &caBundle,
 					Zones:    []string{"bar", "foo"},
 					Taints: []corev1.Taint{
-						corev1.Taint{
+						{
 							Key:    "key",
 							Value:  "value",
 							Effect: corev1.TaintEffectNoExecute,
@@ -296,7 +296,7 @@ func TestExpandShoot(t *testing.T) {
 		Hibernation: &corev1beta1.Hibernation{
 			Enabled: &hibernationEnabled,
 			Schedules: []corev1beta1.HibernationSchedule{
-				corev1beta1.HibernationSchedule{
+				{
 					Start:    &hibernationStart,
 					End:      &hibernationEnd,
 					Location: &location,
@@ -401,7 +401,7 @@ func TestExpandShootAws(t *testing.T) {
 				CIDR: &vpcCIDR,
 			},
 			Zones: []awsAlpha1.Zone{
-				awsAlpha1.Zone{
+				{
 					Name:     "eu-central-1a",
 					Internal: vpcCIDR,
 					Public:   vpcCIDR,

--- a/shoot/expand_spec_test.go
+++ b/shoot/expand_spec_test.go
@@ -57,10 +57,10 @@ func TestExpandShoot(t *testing.T) {
 				"kubernetes": []interface{}{
 					map[string]interface{}{
 						"version": "1.15.4",
-            "allow_privileged_containers": true,
+						"allow_privileged_containers": true,
 						"kube_api_server": []interface{}{
 							map[string]interface{}{
-                "enable_basic_authentication": true,
+								"enable_basic_authentication": true,
 								"audit_config": []interface{}{
 									map[string]interface{}{
 										"audit_policy": []interface{}{

--- a/shoot/flatten_spec_test.go
+++ b/shoot/flatten_spec_test.go
@@ -34,6 +34,8 @@ func TestFlattenShoot(t *testing.T) {
 	hibernationStart := "00 17 * * 1"
 	hibernationEnd := "00 00 * * 1"
 	hibernationEnabled := true
+	allowPrivilegedContainers := true
+	enableBasicAuthentication := true
 
 	d := ResourceShoot().TestResourceData()
 	shoot := corev1beta1.ShootSpec{
@@ -106,7 +108,11 @@ func TestFlattenShoot(t *testing.T) {
 		},
 		Region: "westeurope",
 		Kubernetes: corev1beta1.Kubernetes{
-			Version: "1.15.4",
+			Version:                   "1.15.4",
+			AllowPrivilegedContainers: &allowPrivilegedContainers,
+			KubeAPIServer: &corev1beta1.KubeAPIServerConfig{
+				EnableBasicAuthentication: &enableBasicAuthentication,
+			},
 		},
 		DNS: &corev1beta1.DNS{
 			Domain: &domain,
@@ -156,7 +162,13 @@ func TestFlattenShoot(t *testing.T) {
 			},
 			"kubernetes": []interface{}{
 				map[string]interface{}{
-					"version": "1.15.4",
+					"version":                     "1.15.4",
+					"allow_privileged_containers": true,
+					"kube_api_server": []interface{}{
+						map[string]interface{}{
+							"enable_basic_authentication": true,
+						},
+					},
 				},
 			},
 			"maintenance": []interface{}{


### PR DESCRIPTION
**Description**
When I want to enable basic authentication in the kube api server as show in the `shoot` [schema](https://github.com/kyma-incubator/terraform-provider-gardener/blob/master/shoot/schema_shoot.go#L119), this property is not handed over to Gardener.

Changes proposed in this pull request:
- add missing expand functionality for `enable_basic_authentication`
