### PR TITLE
fix flatten for oidc config

### DIFF
--- a/flatten/flatten_spec.go
+++ b/flatten/flatten_spec.go
@@ -154,11 +154,7 @@ func flattenKubernetes(in corev1beta1.Kubernetes) []interface{} {
 		att["allow_privileged_containers"] = *in.AllowPrivilegedContainers
 	}
 	if in.KubeAPIServer != nil {
-		server := make(map[string]interface{})
-		if in.KubeAPIServer.EnableBasicAuthentication != nil {
-			server["enable_basic_authentication"] = *in.KubeAPIServer.EnableBasicAuthentication
-		}
-		att["kube_api_server"] = []interface{}{server}
+		att["kube_api_server"] = flattenKubeAPIServer(in.KubeAPIServer)
 	}
 	if in.KubeControllerManager != nil {
 		manager := make(map[string]interface{})
@@ -199,6 +195,50 @@ func flattenKubernetes(in corev1beta1.Kubernetes) []interface{} {
 			scaler["scale_down_utilization_threshold"] = in.ClusterAutoscaler.ScaleDownUtilizationThreshold
 		}
 		att["cluster_autoscaler"] = []interface{}{scaler}
+	}
+
+	return []interface{}{att}
+}
+
+func flattenKubeAPIServer(in *corev1beta1.KubeAPIServerConfig) []interface{} {
+	att := make(map[string]interface{})
+
+	if in.EnableBasicAuthentication != nil {
+		att["enable_basic_authentication"] = *in.EnableBasicAuthentication
+	}
+
+	if in.OIDCConfig != nil {
+		config := make(map[string]interface{})
+
+		if in.OIDCConfig.CABundle != nil {
+			config["ca_bundle"] = *in.OIDCConfig.CABundle
+		}
+		if in.OIDCConfig.ClientID != nil {
+			config["client_id"] = *in.OIDCConfig.ClientID
+		}
+		if in.OIDCConfig.GroupsClaim != nil {
+			config["groups_claim"] = *in.OIDCConfig.GroupsClaim
+		}
+		if in.OIDCConfig.GroupsPrefix != nil {
+			config["groups_prefix"] = *in.OIDCConfig.GroupsPrefix
+		}
+		if in.OIDCConfig.IssuerURL != nil {
+			config["issuer_url"] = *in.OIDCConfig.IssuerURL
+		}
+		if in.OIDCConfig.RequiredClaims != nil {
+			config["required_claims"] = in.OIDCConfig.RequiredClaims
+		}
+		if len(in.OIDCConfig.SigningAlgs) > 0 {
+			config["signing_algs"] = in.OIDCConfig.SigningAlgs
+		}
+		if in.OIDCConfig.UsernameClaim != nil {
+			config["username_claim"] = *in.OIDCConfig.UsernameClaim
+		}
+		if in.OIDCConfig.UsernamePrefix != nil {
+			config["username_prefix"] = *in.OIDCConfig.UsernamePrefix
+		}
+
+		att["oidc_config"] = []interface{}{config}
 	}
 
 	return []interface{}{att}

--- a/shoot/expand_spec_test.go
+++ b/shoot/expand_spec_test.go
@@ -38,6 +38,12 @@ func TestExpandShoot(t *testing.T) {
 	hibernationEnabled := true
 	allowPrivilegedContainers := true
 	enableBasicAuthentication := true
+	clientID := "ClientID"
+	groupsClaim := "GroupsClaim"
+	groupsPrefix := "GroupsPrefix"
+	issuerURL := "IssuerURL"
+	usernameClaim := "UsernameClaim"
+	usernamePrefix := "UsernamePrefix"
 
 	shoot := map[string]interface{}{
 		"spec": []interface{}{
@@ -61,6 +67,19 @@ func TestExpandShoot(t *testing.T) {
 						"kube_api_server": []interface{}{
 							map[string]interface{}{
 								"enable_basic_authentication": true,
+								"oidc_config": []interface{}{
+									map[string]interface{}{
+										"ca_bundle":       caBundle,
+										"client_id":       clientID,
+										"groups_claim":    groupsClaim,
+										"groups_prefix":   groupsPrefix,
+										"issuer_url":      issuerURL,
+										"required_claims": map[string]interface{}{"key": "value"},
+										"signing_algs":    []interface{}{"foo", "bar"},
+										"username_claim":  usernameClaim,
+										"username_prefix": usernamePrefix,
+									},
+								},
 								"audit_config": []interface{}{
 									map[string]interface{}{
 										"audit_policy": []interface{}{
@@ -268,6 +287,17 @@ func TestExpandShoot(t *testing.T) {
 			AllowPrivilegedContainers: &allowPrivilegedContainers,
 			KubeAPIServer: &corev1beta1.KubeAPIServerConfig{
 				EnableBasicAuthentication: &enableBasicAuthentication,
+				OIDCConfig: &corev1beta1.OIDCConfig{
+					CABundle:       &caBundle,
+					ClientID:       &clientID,
+					GroupsClaim:    &groupsClaim,
+					GroupsPrefix:   &groupsPrefix,
+					IssuerURL:      &issuerURL,
+					RequiredClaims: map[string]string{"key": "value"},
+					SigningAlgs:    []string{"bar", "foo"},
+					UsernameClaim:  &usernameClaim,
+					UsernamePrefix: &usernamePrefix,
+				},
 				AuditConfig: &corev1beta1.AuditConfig{
 					AuditPolicy: &corev1beta1.AuditPolicy{
 						ConfigMapRef: &corev1.ObjectReference{

--- a/shoot/flatten_spec_test.go
+++ b/shoot/flatten_spec_test.go
@@ -3,8 +3,9 @@ package shoot
 
 import (
 	"encoding/json"
-	gcpAlpha1 "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/v1alpha1"
 	"testing"
+
+	gcpAlpha1 "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/v1alpha1"
 
 	awsAlpha1 "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
 	azAlpha1 "github.com/gardener/gardener-extension-provider-azure/pkg/apis/azure/v1alpha1"
@@ -36,6 +37,12 @@ func TestFlattenShoot(t *testing.T) {
 	hibernationEnabled := true
 	allowPrivilegedContainers := true
 	enableBasicAuthentication := true
+	clientID := "ClientID"
+	groupsClaim := "GroupsClaim"
+	groupsPrefix := "GroupsPrefix"
+	issuerURL := "IssuerURL"
+	usernameClaim := "UsernameClaim"
+	usernamePrefix := "UsernamePrefix"
 
 	d := ResourceShoot().TestResourceData()
 	shoot := corev1beta1.ShootSpec{
@@ -112,6 +119,17 @@ func TestFlattenShoot(t *testing.T) {
 			AllowPrivilegedContainers: &allowPrivilegedContainers,
 			KubeAPIServer: &corev1beta1.KubeAPIServerConfig{
 				EnableBasicAuthentication: &enableBasicAuthentication,
+				OIDCConfig: &corev1beta1.OIDCConfig{
+					CABundle:       &caBundle,
+					ClientID:       &clientID,
+					GroupsClaim:    &groupsClaim,
+					GroupsPrefix:   &groupsPrefix,
+					IssuerURL:      &issuerURL,
+					RequiredClaims: map[string]string{"key": "value"},
+					SigningAlgs:    []string{"bar", "foo"},
+					UsernameClaim:  &usernameClaim,
+					UsernamePrefix: &usernamePrefix,
+				},
 			},
 		},
 		DNS: &corev1beta1.DNS{
@@ -167,6 +185,19 @@ func TestFlattenShoot(t *testing.T) {
 					"kube_api_server": []interface{}{
 						map[string]interface{}{
 							"enable_basic_authentication": true,
+							"oidc_config": []interface{}{
+								map[string]interface{}{
+									"ca_bundle":       caBundle,
+									"client_id":       clientID,
+									"groups_claim":    groupsClaim,
+									"groups_prefix":   groupsPrefix,
+									"issuer_url":      issuerURL,
+									"required_claims": map[string]string{"key": "value"},
+									"signing_algs":    []string{"bar", "foo"},
+									"username_claim":  usernameClaim,
+									"username_prefix": usernamePrefix,
+								},
+							},
 						},
 					},
 				},

--- a/shoot/schema_shoot.go
+++ b/shoot/schema_shoot.go
@@ -155,14 +155,16 @@ func kubernetesResource() *schema.Resource {
 										Optional:    true,
 									},
 									"required_claims": {
-										Type:        schema.TypeString,
+										Type:        schema.TypeMap,
 										Description: "required_claims for oidc config in kube api server section",
 										Optional:    true,
 									},
 									"signing_algs": {
-										Type:        schema.TypeString,
+										Type:        schema.TypeSet,
 										Description: "signing_algs for oidc config in kube api server section",
 										Optional:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Set:         schema.HashString,
 									},
 									"username_claim": {
 										Type:        schema.TypeString,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The current implementation for flatten of the kube API server is not including the OIDC config. This should be fixed with this change. In addition the schema for the `signing_algs` and `required_claims` was not correct. Based on the Gardener API this needs to be a Set/ Map instead of a string.

Changes proposed in this pull request:

- include flatten function for `oidc_config`
- fix schema for `signing_algs`
- fix schema for `required_claims`
