### PR TITLE
fix missing flatten for audit config

### DIFF
--- a/flatten/flatten_spec.go
+++ b/flatten/flatten_spec.go
@@ -241,6 +241,28 @@ func flattenKubeAPIServer(in *corev1beta1.KubeAPIServerConfig) []interface{} {
 		att["oidc_config"] = []interface{}{config}
 	}
 
+	if in.AuditConfig != nil {
+		config := make(map[string]interface{})
+
+		if in.AuditConfig.AuditPolicy != nil {
+			policy := make(map[string]interface{})
+
+			if in.AuditConfig.AuditPolicy.ConfigMapRef != nil {
+				reference := make(map[string]interface{})
+
+				if len(in.AuditConfig.AuditPolicy.ConfigMapRef.Name) > 0 {
+					reference["name"] = in.AuditConfig.AuditPolicy.ConfigMapRef.Name
+				}
+
+				policy["config_map_ref"] = []interface{}{reference}
+			}
+
+			config["audit_policy"] = []interface{}{policy}
+		}
+
+		att["audit_config"] = []interface{}{config}
+	}
+
 	return []interface{}{att}
 }
 

--- a/shoot/flatten_spec_test.go
+++ b/shoot/flatten_spec_test.go
@@ -130,6 +130,13 @@ func TestFlattenShoot(t *testing.T) {
 					UsernameClaim:  &usernameClaim,
 					UsernamePrefix: &usernamePrefix,
 				},
+				AuditConfig: &corev1beta1.AuditConfig{
+					AuditPolicy: &corev1beta1.AuditPolicy{
+						ConfigMapRef: &corev1.ObjectReference{
+							Name: "audit-policy",
+						},
+					},
+				},
 			},
 		},
 		DNS: &corev1beta1.DNS{
@@ -196,6 +203,19 @@ func TestFlattenShoot(t *testing.T) {
 									"signing_algs":    []string{"bar", "foo"},
 									"username_claim":  usernameClaim,
 									"username_prefix": usernamePrefix,
+								},
+							},
+							"audit_config": []interface{}{
+								map[string]interface{}{
+									"audit_policy": []interface{}{
+										map[string]interface{}{
+											"config_map_ref": []interface{}{
+												map[string]interface{}{
+													"name": "audit-policy",
+												},
+											},
+										},
+									},
 								},
 							},
 						},


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

The flatten functionality for the audit config is missing at the moment. With this missing Terraform always marks the audit config as "changed" and triggers an update for Gardener even though this was already done in the previous run.
